### PR TITLE
Add optional FileReader to FileAPIReader.

### DIFF
--- a/src/filereader.js
+++ b/src/filereader.js
@@ -5,9 +5,9 @@
  */
 
 (function(ns) {
-    ns["FileAPIReader"] = function(file) {
+    ns["FileAPIReader"] = function(file, opt_reader) {
         return function(url, fncCallback, fncError) {
-            var reader = new FileReader();
+            var reader = opt_reader || new FileReader();
 
             reader.onload = function(event) {
                 var result = event.target.result;


### PR DESCRIPTION
This allows a user to set an external FileReader instance, therefore providing the ability to reuse the same FileReader instance in serial reads for better memory management.
