### PR TITLE
fix bug in reading MIME type in APIC frame: the MIME is not encoded

### DIFF
--- a/src/id3v2frames.js
+++ b/src/id3v2frames.js
@@ -85,7 +85,7 @@
                 
             case '3':
             case '4':
-                var format = data.getStringWithCharsetAt(offset+1, length - (offset-start), charset);
+                var format = data.getStringWithCharsetAt(offset+1, length - (offset-start), '');
                 offset += 1 + format.bytesReadCount;
                 break;
         }


### PR DESCRIPTION
According the spec, the MIME type in APIC is pure text string without text encoding for the description. 

This bug can be reproduced by adding APIC frame with UTF-16 encoding.  When the text encoding is UTF-16, we will read too many bytes as MIME type, and then fail to parse the description and picture data.
