### PR TITLE
Fixed 'If-Modified-Since' date format

### DIFF
--- a/src/bufferedbinaryajax.js
+++ b/src/bufferedbinaryajax.js
@@ -71,7 +71,7 @@ var BufferedBinaryAjax = function(strUrl, fncCallback, fncError) {
 				oHTTP.setRequestHeader("Range", "bytes=" + aRange[0] + "-" + aRange[1]);
 			}
 
-			oHTTP.setRequestHeader("If-Modified-Since", "Sat, 1 Jan 1970 00:00:00 GMT");
+			oHTTP.setRequestHeader("If-Modified-Since", "Sat, 01 Jan 1970 00:00:00 GMT");
 
 			oHTTP.send(null);
 		} else {


### PR DESCRIPTION
Hi,

My IIS 8.5 server was causing me trouble with the If-Modified-Since header, and returning a 400 code. After investigating it seems that the date should be in RFC822 or RFC1123 format, and both of them require that the day be formatted with a leading 0.

Anyway, adding the 0 fixed my problem.

Hope that helps someone else.

Cheers
Xavier